### PR TITLE
Move about to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import Hero from '../components/Hero'
 import Footer from '../components/Footer'
 import PortfolioCards from '../components/PortfolioCards'
+import About from '../components/About'
 
 export default function Page() {
   return (
     <div>
       <Hero />
       <PortfolioCards />
+      <About />
       <Footer />
     </div>
   )

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable react/no-unescaped-entities */
 import type { Metadata } from 'next'
-import Testimonials from '../../components/Testimonials'
+import Testimonials from './Testimonials'
 
 export const metadata: Metadata = {
   title: 'About',
   description: 'React Product Engineer at Really Good Emails',
 }
 
-export default function AboutPage() {
+export default function About() {
   return (
     <div className="px-6 pt-6 lg:px-8">
       <section>
@@ -56,18 +56,4 @@ export default function AboutPage() {
       </section>
     </div>
   )
-}
-
-{
-  /* <h1 className="font-bold text-3xl font-serif">About Me</h1> */
-}
-{
-  /* <p className="my-5 text-neutral-800">
-    Hey, I'm Christina. Most folks know me as <b>Tina</b>.
-  </p>
-  <div className="prose prose-neutral text-neutral-800">
-    <p>
-      I'm currently the <b>React Product Engineer at Really Good Emails</b>,
-      where I lead our SaaS product development.
-    </p> */
 }

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function About() {
   return (
     <div className="px-6 pt-6 lg:px-8">
-      <section>
+      <section id="about">
         <div className="relative px-6 lg:px-8">
           <div className="mx-auto max-w-2xl py-32 sm:py-48 lg:py-24">
             <div className="text-left">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -10,7 +10,7 @@ import {
 
 const navigation = [
   { name: 'Portfolio', href: '/portfolio' },
-  { name: 'About', href: '/about' },
+  { name: 'About', href: '/#about' },
   {
     name: 'GitHub',
     href: 'https://github.com/cguliuzza',


### PR DESCRIPTION
## Description
Remove the About page. Replaced with an About component on the home page.

## Motivation and Context
I'm moving all components to the Home Page to have a single page, scrollable site.