### PR TITLE
[#34] Fix profile image height

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -8,7 +8,7 @@ export default function About() {
       <div className="relative px-12 pt-6 lg:px-8">
         <div className="mx-auto max-w-2xl py-32 sm:py-48 lg:py-24 flex flex-col gap-10 sm:flex-row">
           <Image
-            className="aspect-[4/5] w-52 flex-none rounded-2xl object-cover"
+            className="aspect-[4/5] mb-auto w-52 flex-none rounded-2xl object-cover"
             src={aboutme}
             alt="Christina Guliuzza portrait"
           />


### PR DESCRIPTION
Fixes #34 

## Description
Adding `mb-auto` prevents the image from taking up the entire height of the content in the same row.

### ☆☆☆ Before ☆☆☆
<img width="931" alt="Screenshot 2023-03-08 at 8 22 40 AM" src="https://user-images.githubusercontent.com/87393712/223770496-62a55f47-dc1a-4dc0-bf97-bfb916509a96.png">


### ★★★ After ★★★
<img width="1032" alt="Screenshot 2023-03-08 at 8 22 13 AM" src="https://user-images.githubusercontent.com/87393712/223770520-29d05871-545a-47a2-b32e-3b65c614cd14.png">
