### PR TITLE
[#25] Remove home from navigation

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,11 +2,7 @@
 
 import { useState } from 'react'
 import { Dialog } from '@headlessui/react'
-import {
-  Bars3Icon,
-  XMarkIcon,
-  HomeModernIcon,
-} from '@heroicons/react/24/outline'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 
 const navigation = [
   {
@@ -38,14 +34,6 @@ export default function Navbar() {
         className="mx-auto flex max-w-7xl items-center justify-between gap-x-6 p-6 lg:px-8"
         aria-label="Global"
       >
-        <div className="flex lg:flex-1 hover:text-cyan-600">
-          <a href="/" className="-m-1.5 p-1.5">
-            <span className="sr-only">
-              Christina Guliuzza | React Product Engineer
-            </span>
-            <HomeModernIcon className="h-8 w-auto" />
-          </a>
-        </div>
         <div className="hidden lg:flex lg:gap-x-12">
           {navigation.map((item) => (
             <a
@@ -87,12 +75,6 @@ export default function Navbar() {
         <div className="fixed inset-0 z-10" />
         <Dialog.Panel className="fixed inset-y-0 right-0 z-10 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-slate-900/10">
           <div className="flex items-center gap-x-6">
-            <a href="/" className="-m-1.5 p-1.5">
-              <span className="sr-only">
-                Christina Guliuzza | React Product Engineer
-              </span>
-              <HomeModernIcon className="h-8 w-auto" />
-            </a>
             <a
               href="/#contact"
               className="ml-auto rounded-md bg-cyan-600 py-2 px-3 text-sm font-semibold text-white shadow-sm hover:bg-cyan-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-600"


### PR DESCRIPTION
Fixes #25 

## Description
The home icon and link have been removed from the header and mobile navigation menu.

## Motivation and Context
The website is a simple, single page, scrollable website. A simple clean up to decrease cognitive load for the user.

### ☆☆☆ Before ☆☆☆
<img width="1110" alt="Screenshot 2023-03-08 at 8 44 10 AM" src="https://user-images.githubusercontent.com/87393712/223775684-b609f10e-0e95-473c-b22b-12949291ba18.png">
<img width="390" alt="Screenshot 2023-03-08 at 8 44 24 AM" src="https://user-images.githubusercontent.com/87393712/223775705-32a0ab29-9721-435d-8b66-eebe7f3ff9d9.png">
<img width="388" alt="Screenshot 2023-03-08 at 8 44 33 AM" src="https://user-images.githubusercontent.com/87393712/223775718-524c507a-254c-4ad9-9269-49485bea0a06.png">


### ★★★ After ★★★
<img width="1046" alt="Screenshot 2023-03-08 at 8 45 34 AM" src="https://user-images.githubusercontent.com/87393712/223775822-2c4f6d40-767e-4e59-9c6a-e57a478d0690.png">

<img width="424" alt="Screenshot 2023-03-08 at 8 45 08 AM" src="https://user-images.githubusercontent.com/87393712/223775759-40950b41-0e99-4c0e-8ace-03f341b28203.png">

<img width="424" alt="Screenshot 2023-03-08 at 8 45 18 AM" src="https://user-images.githubusercontent.com/87393712/223775844-b7bb7a1b-eafe-438c-94c8-5859222a5b6d.png">
