### PR TITLE
[#38] Improve about component styling

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -5,14 +5,14 @@ import aboutme from '../public/images/aboutme.jpeg'
 export default function About() {
   return (
     <section>
-      <div className="relative px-12 pt-6 lg:px-8">
-        <div className="mx-auto max-w-2xl py-32 sm:py-48 lg:py-24 flex flex-col gap-10 sm:flex-row">
+      <div className="relative px-12 py-32 lg:px-8">
+        <div className="mx-auto max-w-7xl px-6 flex flex-col gap-10 lg:flex-row">
           <Image
-            className="aspect-[4/5] mb-auto w-52 flex-none rounded-2xl object-cover"
+            className="aspect-[4/5] mb-auto flex-none rounded-2xl object-cover w-1/2"
             src={aboutme}
             alt="Christina Guliuzza portrait"
           />
-          <div className="text-left">
+          <div className="text-left flex flex-col justify-center">
             <h2 className="text-3xl font-light tracking-normal">
               Christina Guliuzza
             </h2>


### PR DESCRIPTION
Fixes #38
Collaborated with @dcpomfret 

## Description
Improve the about section layout. 

- Same width and padding as the testimony component above.
- The about copy is aligned and centered
- The image takes up 50% of the flex row

### ☆☆☆ Before ☆☆☆
<img width="1417" alt="Screenshot 2023-03-08 at 11 17 09 AM" src="https://user-images.githubusercontent.com/87393712/223819458-ea1f0975-4b24-4d80-a7ec-e046e3b92cc6.png">


### ★★★ After ★★★
<img width="1418" alt="Screenshot 2023-03-08 at 11 17 27 AM" src="https://user-images.githubusercontent.com/87393712/223819420-be6cb06f-990c-4900-b386-33ac30061e1f.png">
