### PR TITLE
Add current year to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,7 @@
 import { SVGProps } from 'react'
 
+const currentYear = new Date().getFullYear()
+
 const navigation = {
   main: [
     {
@@ -39,10 +41,7 @@ export default function Footer() {
   return (
     <footer className="bg-white">
       <div className="mx-auto max-w-7xl overflow-hidden py-20 px-6 sm:py-24 lg:px-8">
-        <nav
-          className="-mb-6 columns-2 sm:flex sm:justify-center sm:space-x-12"
-          aria-label="Footer"
-        >
+        <nav className="-mb-6 flex justify-center" aria-label="Footer">
           {navigation.main.map((item) => (
             <div key={item.name} className="p-6">
               <a
@@ -67,7 +66,8 @@ export default function Footer() {
           ))}
         </div>
         <p className="mt-10 text-center text-xs leading-5 text-slate-500">
-          &copy; 2023 Christina Guliuzza, Inc. All rights reserved.
+          &copy;<span> {currentYear} </span>Christina Guliuzza, Inc. All rights
+          reserved.
         </p>
       </div>
     </footer>


### PR DESCRIPTION
### Description
- Add currentYear function
- Center main nav for mobile view

### Resources
https://stackoverflow.com/questions/6002254/get-the-current-year-in-javascript?rq=1


### ☆☆☆ Before ☆☆☆
<img width="460" alt="Screenshot 2023-03-08 at 5 02 57 PM" src="https://user-images.githubusercontent.com/87393712/223888222-458abb4a-3ffb-44c6-bc47-2f5784418161.png">

### ★★★ After ★★★
<img width="457" alt="Screenshot 2023-03-08 at 5 02 42 PM" src="https://user-images.githubusercontent.com/87393712/223888239-edc7db94-7f7e-4657-97fc-0a83dd2d837c.png">

